### PR TITLE
Fix audio flag inversion, ensure there is always audio when it's not disabled.

### DIFF
--- a/process.go
+++ b/process.go
@@ -57,6 +57,10 @@ func (p Process) Spawn(path, URI string) *exec.Cmd {
 		"tcp",
 		"-i",
 		URI,
+		"-f",
+		"lavfi",
+		"-i",
+		"anullsrc=channel_layout=stereo:sample_rate=44100",
 		"-vsync",
 		"0",
 		"-copyts",
@@ -65,7 +69,7 @@ func (p Process) Spawn(path, URI string) *exec.Cmd {
 		"-movflags",
 		"frag_keyframe+empty_moov",
 	}
-	if p.audio {
+	if (!p.audio) {
 		processCommands = append(processCommands, "-an")
 	}
 	processCommands = append(processCommands,


### PR DESCRIPTION
In the current code the audio flag is wrongly inverted. Additionally, the destination stream may not have audio even though the audio flag is enabled. 

This fixes the inversion and adds a silent audio stream when audio is enabled, which is required by many streaming devices, particularly Chromecast. 